### PR TITLE
revamp DLL sections, implement data-relocations, add BSS, implement FST

### DIFF
--- a/src/main/java/n64loaderwv/DPDLL.java
+++ b/src/main/java/n64loaderwv/DPDLL.java
@@ -1,10 +1,13 @@
 package n64loaderwv;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.python.jline.internal.Log;
 
@@ -42,65 +45,53 @@ import ghidra.util.Msg;
 import ghidra.util.exception.InvalidInputException;
 import ghidra.util.task.TaskMonitor;
 
+import n64loaderwv.Utils;
+
 public class DPDLL 
 {
 	private Program program;
 	public int dll_id;
 	public int dll_rom_offset;
 	public int dll_tab_offset;
+	public int dll_bss;
 	public int dll_size;
 	public int hdr_size;
-	public int hdr_offset_data2;
-	public int hdr_offset_constants; // includes import/export function table
-	public short hdr_unk1;
+	public int hdr_offset_data;
+	public int hdr_offset_rodata; // begins with relocation table
+	public short hdr_export_count;
 	public int code_offset;
 	public int code_size;
-	public int constants_offset;
-	private long dll_address;
-	private long code_address;
-	private AddressSpace address_space;
+	public int rodata_offset;
 	private long load_address;
+	private long code_address;
+	private long rodata_address;
+	private long data_address;
+	private AddressSpace address_space;
 	public String dll_identifier;
 	public String dll_block_name;
-	
-	private long MakeRomAddress(int romOffset)
+
+	private int GetHeaderInitFuncOffset()
 	{
-		return load_address + (romOffset - 0x1000);
+		return 0x10;
 	}
-	
+
+	private int GetHeaderFiniFuncOffset()
+	{
+		return 0x14;
+	}
+
 	private int GetHeaderExportFuncOffset(int idx)
 	{
-		return dll_rom_offset + 16 + 4 * idx;
+		return 0x1C + 4 * idx;
 	}
 	
-	private long GetFunctionAddress(int aOffset)
-	{
-		// every(?) DLL function starts with some code that's patched by the game
-		// it sets up the gp register for the function
-		// atm we just set the register value, we could also patch the instructions
-		int addFuncOffset = 0;// aIsExport ? 0xC : 0;
-		
-		long funcAddr = code_address + aOffset + addFuncOffset;
-		
-		return funcAddr;
-	}
-	
-	// move to some utility thing
-	private static void MakeConstantPtr(Program p, Address addr) throws CodeUnitInsertionException
-	{
-		Data d = DataUtilities.createData(p, addr, PointerDataType.dataType, -1, false,
-				ClearDataMode.CLEAR_ALL_UNDEFINED_CONFLICT_DATA);
-
-		// you have no idea how long it took me to find how to fucking set this property
-		MutabilitySettingsDefinition.DEF.setChoice(d, MutabilitySettingsDefinition.CONSTANT);
-	}
-	
-	public DPDLL(Program aProgram, int aId, int aRomStartOffset, int aTabOffset, int aSize) 
+	public DPDLL(Program aProgram, int aId, int aRomStartOffset, int aTabOffset, int aBssSize, int aSize)
 	{
 		program = aProgram;
 		dll_id = aId;
 		dll_rom_offset = aRomStartOffset;
 		dll_tab_offset = aTabOffset;
+		dll_bss = aBssSize;
 		dll_size = aSize;
 		address_space = program.getAddressFactory().getDefaultAddressSpace();
 	}
@@ -113,23 +104,22 @@ public class DPDLL
 		
 		handle.setPointerIndex(dll_rom_offset);
 		hdr_size = handle.readNextInt();
-		hdr_offset_data2 = handle.readNextInt(); // can be -1
-		hdr_offset_constants = handle.readNextInt();
-		hdr_unk1 = handle.readNextShort();
-		code_offset = dll_rom_offset + hdr_size;
+		hdr_offset_data = handle.readNextInt();
+		hdr_offset_rodata = handle.readNextInt();
+		hdr_export_count = handle.readNextShort();
+		code_offset = hdr_size;
 		code_size = dll_size - hdr_size;
-		constants_offset = dll_rom_offset + hdr_offset_constants;
-		
+
 		Log.info(String.format("DP: DLL %d @ 0x%08X", dll_id, dll_rom_offset));
 
-		dll_address = MakeRomAddress(dll_rom_offset);
-		code_address = MakeRomAddress(code_offset);
-		//constants_address = MakeRomAddress(dll_rom_offset + hdr_offset_constants);
-		
+		code_address = load_address + code_offset;
+		rodata_address = load_address + hdr_offset_rodata;
+		data_address = load_address + hdr_offset_data;
+
 		dll_identifier = String.format("dll_%03d", dll_id);
 		dll_block_name = dll_identifier;
 		String usedObjectName = null;
-		
+
 		if (objects.dllidx_to_objname.containsKey(dll_id))
 		{
 			usedObjectName = objects.dllidx_to_objname.get(dll_id);
@@ -150,35 +140,18 @@ public class DPDLL
 			String dllBlockDesc = String.format("DLL %d (used object=%s), ROM address 0x%08X, DLLS.BIN offset 0x%08X, DLLS.TAB offset 0x%08X"
 											, dll_id, usedObjectName != null ? usedObjectName : "NONE", dll_rom_offset, dll_tab_offset, 0x10 + dll_id * 8);
 			
-			MemoryBlockUtils.createInitializedBlock(
-					program, false, "." + dll_block_name, address_space.getAddress(code_address), 
-					s.getInputStream(code_offset), code_size, dllBlockDesc, 
+			ByteArrayOutputStream out_stream = new ByteArrayOutputStream();
+			out_stream.write(s.readBytes(dll_rom_offset, dll_size));
+			out_stream.write(new byte[dll_bss]);
+			byte[] dll_data = out_stream.toByteArray();
+			InputStream in_stream = new ByteArrayInputStream(dll_data);
+			
+			MemoryBlock block = MemoryBlockUtils.createInitializedBlock(
+					program, false, "." + dll_block_name, address_space.getAddress(load_address),
+					in_stream, dll_size + dll_bss, dllBlockDesc,
 					null, true, true, true, log, monitor);
 			
-			// constants block
-			/*String constantsBlockName = String.format(".%s_constants", dllIdentifier);
-			Address constantsStartAddr = address_space.getAddress(constants_address);
-			Address constantsEndAddr = address_space.getAddress(constants_address + constants_size);
-
-			MemoryBlockUtils.createInitializedBlock(
-					program, false, constantsBlockName, constantsStartAddr, 
-					s.getInputStream(constants_offset), constants_size, null, 
-					null, true, false, false, log, monitor);*/
-			
-			// mark constant data as constant, helps ghidra show noice function calls
-			/*Address constantsStartAddr = address_space.getAddress(constants_address);
-			Address constantsEndAddr = address_space.getAddress(constants_address + constants_size);
-			
-			AddressSetView addrSetConstantData = new AddressSet(constantsStartAddr, constantsEndAddr);
-			DataIterator dataIt = program.getListing().getData(addrSetConstantData, true);
-			
-			while (dataIt.hasNext())
-			{
-				Data data = dataIt.next();
-				
-				// this only works before the data is analyzed, we probably need to CreateData explicitly
-				MutabilitySettingsDefinition.DEF.setChoice(d, MutabilitySettingsDefinition.CONSTANT);
-			}*/
+			address_space = block.getStart().getAddressSpace();
 		}
 		catch (Exception e) 
 		{
@@ -210,101 +183,117 @@ public class DPDLL
 		List<FuncInfo> functions = new ArrayList<FuncInfo>();
 		
 		// patch the export function offsets to address of the func in the rom
-		int num_exports = (hdr_size - 16) / 4;
-		
-		for (int i = 0; i < num_exports; ++i)
+		for (int i = 0; i < hdr_export_count + 2; ++i)
 		{
-			int exportOffset = GetHeaderExportFuncOffset(i);
-			long offsetAddr = MakeRomAddress(exportOffset);
-			int funcOffset = handle.readInt(exportOffset);
-			long funcAddress = GetFunctionAddress(funcOffset);
+			int exportOffset = 0;
+			if (i == 0) exportOffset = GetHeaderInitFuncOffset();
+			else if (i == 1) exportOffset = GetHeaderFiniFuncOffset();
+			else exportOffset = GetHeaderExportFuncOffset(i - 2);
+
+			long offsetAddr = load_address + exportOffset;
+			int funcOffset = handle.readInt(dll_rom_offset + exportOffset);
+			long funcAddress = code_address + funcOffset;
 			Address writeAddr = address_space.getAddress(offsetAddr);
 			mem.setInt(writeAddr, (int)funcAddress);
-			MakeConstantPtr(program, writeAddr);
-			
+			Utils.MakeConstantPtr(program, writeAddr);
+
 			functions.add(new FuncInfo(true, false, funcOffset));
 		}
-
-		long dataAddress = dll_address + hdr_offset_constants;
-		long writeAddress = dataAddress - 4;
 		
-		Register reg = program.getLanguage().getRegister("gp");
-		Address regAddrStart = address_space.getAddress(dll_address);
-		Address regAddrEnd = address_space.getAddress(dll_address + dll_size);
-		ctx.setValue(reg, regAddrStart, regAddrEnd, BigInteger.valueOf(dataAddress));
-		
-		handle.setPointerIndex(dll_rom_offset + hdr_offset_constants);
-		
-		int rom_DLLSIMPORTTAB_offset = 0x3B064DC;
-		
-		// imports table
-		while (true)
+		// relocation table
+		if (hdr_offset_rodata != -1)
 		{
-			writeAddress += 4;
-			int val = handle.readNextInt();
+			Register reg = program.getLanguage().getRegister("gp");
+			Address regAddrStart = address_space.getAddress(load_address);
+			Address regAddrEnd = address_space.getAddress(load_address + dll_size + dll_bss - 1);
+			ctx.setValue(reg, regAddrStart, regAddrEnd, BigInteger.valueOf(rodata_address));
+			
+			handle.setPointerIndex(dll_rom_offset + hdr_offset_rodata);
+			
+			int rom_DLLSIMPORTTAB_offset = DPFST.offsets.get(72);
+			
+			long writeAddress = rodata_address - 4;
+			
+			// rodata table
+			while (true)
+			{
+				writeAddress += 4;
+				int val = handle.readNextInt();
 
-			if (val == -2)
-				break;
-			
-			long writeValue = 0;
-			
-			if ((val & 0x80000000) == 0)
-			{
-				// pointer to address within DLL, string table, etc.
-				writeValue = code_address + val;
-			}
-			else
-			{
-				// pointer to main executable function
-				int importTabOffset = (val & 0x7FFFFFFF) * 4 - 4;
-				writeValue = handle.readUnsignedInt(rom_DLLSIMPORTTAB_offset + importTabOffset); 
-			}
-			
-			Address targetAddr = address_space.getAddress(writeAddress);
-			
-			mem.setInt(targetAddr, (int)writeValue);
-			MakeConstantPtr(program, targetAddr);
-		}
-		
-		// function table
-		while (true)
-		{
-			int val = handle.readNextInt();
-			
-			if (val == -3)
-				break;
-			
-			boolean hasFunc = false;
-			for (int i = 0; i < functions.size() && !hasFunc; ++i)
-			{
-				if (functions.get(i).dll_offset == val)
+				if (val == -2)
+					break;
+
+				long writeValue = 0;
+
+				if ((val & 0x80000000) == 0)
 				{
-					hasFunc = true;
-					functions.get(i).is_local = true;
+					// pointer to address within DLL, string table, etc.
+					writeValue = code_address + val;
+				}
+				else
+				{
+					// pointer to main executable function
+					int importTabOffset = (val & 0x7FFFFFFF) * 4 - 4;
+					writeValue = handle.readUnsignedInt(rom_DLLSIMPORTTAB_offset + importTabOffset); 
+				}
+
+				Address targetAddr = address_space.getAddress(writeAddress);
+
+				mem.setInt(targetAddr, (int)writeValue);
+				Utils.MakeConstantPtr(program, targetAddr);
+			}
+			
+			// text table
+			while (true)
+			{
+				int val = handle.readNextInt();
+
+				if (val == -3)
+					break;
+
+				boolean hasFunc = false;
+				for (int i = 0; i < functions.size() && !hasFunc; ++i)
+				{
+					if (functions.get(i).dll_offset == val)
+					{
+						hasFunc = true;
+						functions.get(i).is_local = true;
+					}
+				}
+
+				if (!hasFunc)
+				{
+					functions.add(new FuncInfo(false, true, val));
 				}
 			}
-			
-			if (!hasFunc)
+
+			if (hdr_offset_data != -1)
 			{
-				functions.add(new FuncInfo(false, true, val));
+				// data table
+				while (true)
+				{
+					int val = handle.readNextInt();
+
+					if (val == -1)
+						break;
+
+					writeAddress = data_address + val;
+		
+					long writeValue = handle.readUnsignedInt(dll_rom_offset + hdr_offset_data + val);
+					writeValue += data_address;
+		
+					Address targetAddr = address_space.getAddress(writeAddress);
+
+					mem.setInt(targetAddr, (int)writeValue);
+					Utils.MakeNormalPtr(program, targetAddr);
+				}
 			}
 		}
-		
-		while (true)
-		{
-			int val = handle.readNextInt();
-			
-			if (val == -1)
-				break;
-			
-			// offsets into the DLL to tables of more values?
-		}
-		
 		// end of table
 		
 		// create functions
-		short dataAddressHi = (short)((dataAddress >> 0x10) & 0xFFFF);
-		short dataAddressLo = (short)(dataAddress & 0xFFFF);
+		short rodataAddressHi = (short)((rodata_address >> 0x10) & 0xFFFF);
+		short rodataAddressLo = (short)(rodata_address & 0xFFFF);
 		
 		for (int i = 0; i < functions.size(); ++i)
 		{
@@ -316,23 +305,26 @@ public class DPDLL
 			if (info.is_export)
 				funcStrFlags += "E";
 
-			String funcName = String.format("%s_func_%04d", dll_block_name, i);
-			
+			String funcName = null;
+			if (i == 0) funcName = String.format("%s_init", dll_block_name);
+			else if (i == 1) funcName = String.format("%s_fini", dll_block_name);
+			else funcName = String.format("%s_func_%04d", dll_block_name, i - 2);
+
 			if (funcStrFlags.length() > 0)
 				funcName += "_" + funcStrFlags;
 			
-			Address addr = address_space.getAddress(GetFunctionAddress(info.dll_offset));
+			Address addr = address_space.getAddress(code_address + info.dll_offset);
 		    program.getSymbolTable().createLabel(addr, funcName, SourceType.ANALYSIS);
 			program.getSymbolTable().addExternalEntryPoint(addr);
 		    
-		    if (info.is_local)
+		    if (info.is_local && hdr_offset_rodata != -1)
 		    {
 		    	// patch the GP register instructions at the start of the function
 		    	// the game does this as well at runtime
 		    	Address loadInstrPatchAddr = addr.add(2);
 		    	Address orInstrPatchAddr = addr.add(6);
-		    	mem.setShort(loadInstrPatchAddr, dataAddressHi);
-		    	mem.setShort(orInstrPatchAddr, dataAddressLo);
+			mem.setShort(loadInstrPatchAddr, rodataAddressHi);
+			mem.setShort(orInstrPatchAddr, rodataAddressLo);
 		    }
 		}
 	}

--- a/src/main/java/n64loaderwv/DPDLLTab.java
+++ b/src/main/java/n64loaderwv/DPDLLTab.java
@@ -36,12 +36,13 @@ public class DPDLLTab
 {
 	public int[] dll_banks;
 	public List<Integer> dll_offsets;
-	
+	public List<Integer> dll_bss_sizes;
+
 	public void Load(ByteArrayProvider s) throws IOException, InvalidInputException
 	{
 		BinaryReader handle = new BinaryReader(s, false);
 		
-		int offset_DLLS_TAB = 0x3B04BDC;
+		int offset_DLLS_TAB = DPFST.offsets.get(71);
 		
 		// read tab
 		handle.setPointerIndex(offset_DLLS_TAB);
@@ -51,28 +52,38 @@ public class DPDLLTab
 		dll_banks[1] = handle.readNextInt();
 		dll_banks[2] = handle.readNextInt();
 		dll_banks[3] = handle.readNextInt();
-		
-		// according to the game the first dll actually starts at 0x8 but this is bank data
-		// not sure why
-		// ignore this and just make correct offsets, we fix the ID later by just adding 1
-		
+
 		dll_offsets = new ArrayList<Integer>();
-		
+		dll_bss_sizes = new ArrayList<Integer>();
+
 		while (true) 
 		{
 			int dllOffset = handle.readNextInt();
-			int dllUnk = handle.readNextInt();
+			int dllBss = handle.readNextInt();
 			
-			if (dllOffset == -1 && dllUnk == -1)
+			if (dllOffset == -1 && dllBss == -1)
 				break;
 			
 			dll_offsets.add(dllOffset);
+			dll_bss_sizes.add(dllBss);
 		}
+	}
+
+	public int GetDLLBssSizeFromIndex(int aIndex)
+	{
+		int dllBss = dll_bss_sizes.get(aIndex);
+		return dllBss;
+	}
+
+	public int GetDLLBssSizeFromEncodedId(int aId)
+	{
+		int index = DecodeDLLId(aId);
+		return GetDLLBssSizeFromIndex(index - 1);
 	}
 	
 	public int GetDLLRomOffsetFromIndex(int aIndex)
 	{
-		int offset_DLLS_BIN = 0x38317CC;
+		int offset_DLLS_BIN = DPFST.offsets.get(70);
 		int tabOffset = dll_offsets.get(aIndex);
 		int dllOffset = offset_DLLS_BIN + tabOffset;
 		return dllOffset;

--- a/src/main/java/n64loaderwv/DPFST.java
+++ b/src/main/java/n64loaderwv/DPFST.java
@@ -1,0 +1,33 @@
+package n64loaderwv;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import ghidra.app.util.bin.BinaryReader;
+import ghidra.app.util.bin.ByteArrayProvider;
+import ghidra.util.exception.InvalidInputException;
+
+public final class DPFST
+{
+	public static List<Integer> offsets;
+
+	public static void Load(ByteArrayProvider s, int offset_FST) throws IOException, InvalidInputException
+	{
+		BinaryReader handle = new BinaryReader(s, false);
+
+		handle.setPointerIndex(offset_FST);
+
+		int count = handle.readNextInt();
+		int offset_FAT = offset_FST + (count + 2) * 4;
+
+		offsets = new ArrayList<Integer>();
+
+		for (int i = 0; i < count + 1; i++)
+		{
+			int offset = handle.readNextInt();
+
+			offsets.add(offset_FAT + offset);
+		}
+	}
+}

--- a/src/main/java/n64loaderwv/DPObjects.java
+++ b/src/main/java/n64loaderwv/DPObjects.java
@@ -41,8 +41,8 @@ public class DPObjects
 	{
 		BinaryReader handle = new BinaryReader(s, false);
 		
-		int rom_OBJECTS_BIN_offset = 0x37EEB42; 
-		int rom_OBJECTS_TAB_offset = 0X37ED766;
+		int rom_OBJECTS_BIN_offset = DPFST.offsets.get(66);
+		int rom_OBJECTS_TAB_offset = DPFST.offsets.get(65);
 		
 		// read tab
 		List<Integer> offsets = new ArrayList<Integer>();

--- a/src/main/java/n64loaderwv/Utils.java
+++ b/src/main/java/n64loaderwv/Utils.java
@@ -1,0 +1,34 @@
+package n64loaderwv;
+
+import ghidra.program.model.address.Address;
+import ghidra.program.model.data.DataUtilities;
+import ghidra.program.model.data.MutabilitySettingsDefinition;
+import ghidra.program.model.data.PointerDataType;
+import ghidra.program.model.data.DataUtilities.ClearDataMode;
+import ghidra.program.model.listing.Data;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.util.CodeUnitInsertionException;
+
+public final class Utils
+{
+	public static long align(long value, long alignment)
+	{
+		return value >= 0 ? ((value + alignment - 1) / alignment) * alignment : (value / alignment) * alignment;
+	}
+
+	public static void MakeConstantPtr(Program p, Address addr) throws CodeUnitInsertionException
+	{
+		Data d = DataUtilities.createData(p, addr, PointerDataType.dataType, -1, false,
+				ClearDataMode.CLEAR_ALL_UNDEFINED_CONFLICT_DATA);
+
+		// you have no idea how long it took me to find how to fucking set this property
+		MutabilitySettingsDefinition.DEF.setChoice(d, MutabilitySettingsDefinition.CONSTANT);
+	}
+
+	public static void MakeNormalPtr(Program p, Address addr) throws CodeUnitInsertionException
+	{
+		Data d = DataUtilities.createData(p, addr, PointerDataType.dataType, -1, false,
+				ClearDataMode.CLEAR_ALL_UNDEFINED_CONFLICT_DATA);
+
+	}
+}


### PR DESCRIPTION
- moved the DLLs out of the RAM section in to their own dedicated sections (above 0x81000000) in order to facilitate the BSS.
- data-section relocations have been implemented and general improvements have been made in understanding of the DLL format - constructor/destructor is now specifically named, etc.
- RAM beyond the end of the FST is cleared to zero to make variables less confusing.
- FST support has been added to avoid the need to recompile the extension if extending any of the assets/files (or adding custom DLLs).
- a couple more DLL names guessed from default.dol strings have been added.

